### PR TITLE
ATS config updates

### DIFF
--- a/salt/fallback_proxy/remap.config
+++ b/salt/fallback_proxy/remap.config
@@ -2,4 +2,4 @@
 # It's unwanted for Lantern, as all non CONNECT requests are plain HTTP ones.
 # Use wildcard remap from https to http to force ATS request through HTTP.
 # It is problematic if the actual destination port is not 80, but would be rare.
-regex_map https://(.*):443/ http://$1:80/
+regex_map https://(.*)/ http://$1/


### PR DESCRIPTION
This will prevent ATS from appending port to "Host" HTTP Header. Fixes https://github.com/getlantern/lantern/issues/3147, again.

As it affects very few sites, it's ok to merge and deploy with other changes.