### PR TITLE
reduce the data points of collectd

### DIFF
--- a/salt/monitor/collectd.conf
+++ b/salt/monitor/collectd.conf
@@ -1,31 +1,17 @@
 # apt-get install collectd
 # then override /etc/collectd/collectd.conf with this file
 Hostname "{{grains['id']}}"
-Interval 300
+Interval 900
 LoadPlugin syslog
 FQDNLookup false
 <Plugin syslog>
 	LogLevel info
 </Plugin>
-LoadPlugin cpu
-LoadPlugin df
-LoadPlugin disk
 LoadPlugin interface
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin network
 LoadPlugin swap
-<Plugin df>
-	FSType rootfs
-	FSType sysfs
-	FSType proc
-	FSType devtmpfs
-	FSType devpts
-	FSType tmpfs
-	FSType fusectl
-	FSType cgroup
-	IgnoreSelected true
-</Plugin>
 <Plugin interface>
 	Interface "eth0"
 	IgnoreSelected false


### PR DESCRIPTION
It increased the collect interval to 15 minutes, and removed lots of measurements we didn't present for now, to prevent InfluxDB from explosion.