### PR TITLE
use http-proxy v0.0.2

### DIFF
--- a/salt/fallback_proxy/convcert.sh
+++ b/salt/fallback_proxy/convcert.sh
@@ -6,5 +6,6 @@ KEY_FILE=/home/lantern/key.pem
 CERT_FILE=/home/lantern/cert.pem
 keytool -v -importkeystore -srckeystore $KEYSTORE -srcalias fallback --srcstorepass "$CERT_PASS" -destkeystore /tmp/keystore.p12 -deststoretype PKCS12 --deststorepass "$CERT_PASS"
 openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $KEY_FILE -passout pass:"$CERT_PASS" -nocerts -nodes
-openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $CERT_FILE -passout pass:"$CERT_PASS" -clcerts -nokeys
-rm /tmp/keystore.p12
+openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out /tmp/cert.pem -passout pass:"$CERT_PASS" -clcerts -nokeys
+openssl x509 -in /tmp/cert.pem -passin pass:"$CERT_PASS" -out $CERT_FILE -passout pass:"$CERT_PASS"
+rm /tmp/keystore.p12 /tmp/cert.pem

--- a/salt/fallback_proxy/convcert.sh
+++ b/salt/fallback_proxy/convcert.sh
@@ -5,7 +5,6 @@ CERT_PASS="Be Your Own Lantern"
 KEY_FILE=/home/lantern/key.pem
 CERT_FILE=/home/lantern/cert.pem
 keytool -v -importkeystore -srckeystore $KEYSTORE -srcalias fallback --srcstorepass "$CERT_PASS" -destkeystore /tmp/keystore.p12 -deststoretype PKCS12 --deststorepass "$CERT_PASS"
-openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $KEY_FILE -passout pass:"$CERT_PASS" -nocerts -nodes
-openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out /tmp/cert.pem -passout pass:"$CERT_PASS" -clcerts -nokeys
-openssl x509 -in /tmp/cert.pem -out $CERT_FILE
-rm /tmp/keystore.p12 /tmp/cert.pem
+openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $KEY_FILE -passout pass:"$CERT_PASS" -nocerts
+keytool -exportcert -alias fallback -storepass "$CERT_PASS" -rfc -keystore /home/lantern/littleproxy_keystore.jks -file $CERT_FILE
+rm /tmp/keystore.p12

--- a/salt/fallback_proxy/convcert.sh
+++ b/salt/fallback_proxy/convcert.sh
@@ -5,6 +5,6 @@ CERT_PASS="Be Your Own Lantern"
 KEY_FILE=/home/lantern/key.pem
 CERT_FILE=/home/lantern/cert.pem
 keytool -v -importkeystore -srckeystore $KEYSTORE -srcalias fallback --srcstorepass "$CERT_PASS" -destkeystore /tmp/keystore.p12 -deststoretype PKCS12 --deststorepass "$CERT_PASS"
-openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $KEY_FILE -passout pass:"$CERT_PASS" -nocerts
+openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $KEY_FILE -passout pass:"$CERT_PASS" -nocerts -nodes
 keytool -exportcert -alias fallback -storepass "$CERT_PASS" -rfc -keystore /home/lantern/littleproxy_keystore.jks -file $CERT_FILE
 rm /tmp/keystore.p12

--- a/salt/fallback_proxy/convcert.sh
+++ b/salt/fallback_proxy/convcert.sh
@@ -7,5 +7,5 @@ CERT_FILE=/home/lantern/cert.pem
 keytool -v -importkeystore -srckeystore $KEYSTORE -srcalias fallback --srcstorepass "$CERT_PASS" -destkeystore /tmp/keystore.p12 -deststoretype PKCS12 --deststorepass "$CERT_PASS"
 openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out $KEY_FILE -passout pass:"$CERT_PASS" -nocerts -nodes
 openssl pkcs12 -in /tmp/keystore.p12 -passin pass:"$CERT_PASS" -out /tmp/cert.pem -passout pass:"$CERT_PASS" -clcerts -nokeys
-openssl x509 -in /tmp/cert.pem -passin pass:"$CERT_PASS" -out $CERT_FILE -passout pass:"$CERT_PASS"
+openssl x509 -in /tmp/cert.pem -out $CERT_FILE
 rm /tmp/keystore.p12 /tmp/cert.pem

--- a/salt/fallback_proxy/init.sls
+++ b/salt/fallback_proxy/init.sls
@@ -181,7 +181,7 @@ install-http-proxy:
 convert-cert:
     cmd.script:
         - source: salt://fallback_proxy/convcert.sh
-        - creates: /home/lantern/key.pem
+        - creates: /home/lantern/cert.pem
         - user: lantern
         - group: lantern
         - mode: 400
@@ -196,7 +196,6 @@ proxy-service:
             - cmd: fallback-proxy-dirs-and-files
             - cmd: convert-cert
             - cmd: install-http-proxy
-            - file: /etc/init.d/http-proxy
         - require:
             - pkg: tcl
             - cmd: ufw-rules-ready

--- a/salt/fallback_proxy/init.sls
+++ b/salt/fallback_proxy/init.sls
@@ -181,7 +181,6 @@ install-http-proxy:
 convert-cert:
     cmd.script:
         - source: salt://fallback_proxy/convcert.sh
-        - creates: /home/lantern/cert.pem
         - user: lantern
         - group: lantern
         - mode: 400

--- a/salt/fallback_proxy/install_http_proxy.sh
+++ b/salt/fallback_proxy/install_http_proxy.sh
@@ -1,8 +1,9 @@
 #! /usr/bin/env sh
 
-echo 'Installing http proxy ...'
+VERSION=v0.0.2
+echo "Installing http proxy $VERSION..."
 rm -f http-proxy.tmp
-curl -L https://github.com/getlantern/http-proxy/releases/download/v0.0.1-mobile/http-proxy -o http-proxy.tmp
+curl -L https://github.com/getlantern/http-proxy/releases/download/$VERSION/http-proxy -o http-proxy.tmp
 chmod u+x http-proxy.tmp
 mv -f http-proxy.tmp http-proxy
 echo 'Done'


### PR DESCRIPTION
v0.0.2 includes @uaalto 's fixes to eliminate the infinite loop to localhost. The changes didn't break Apache mimicking, I just tweaked the test code a bit to stop it from hanging, ref PR https://github.com/getlantern/http-proxy-lantern/pull/8.

@myleshorton and @aranhoide, as per our discussion in stand up, it's probably ok to deploy to Vultr?