### PR TITLE
supply loggly token to http-proxy

### DIFF
--- a/bin/update.py
+++ b/bin/update.py
@@ -92,6 +92,7 @@ def upload_pillars():
     vultr_apikey = util.read_vultr_credential()
     cfgsrv_token, cfgsrv_redis_url = util.read_cfgsrv_credential()
     github_token = util.read_github_token()
+    loggly_token = util.read_loggly_token()
     if not util.in_production():
         cfgsrv_redis_url = "redis://%s:6379" % config.cloudmaster_address
     util.ssh_cloudmaster((
@@ -108,8 +109,9 @@ def upload_pillars():
             ' && echo "cfgsrv_token: %s" > cfgsrv_credential.sls'
             ' && echo "cfgsrv_redis_url: %s" >> cfgsrv_credential.sls'
             ' && echo "github_token: %s" > github_token.sls'
-            r' && echo "base: {\"*\": [salt, global], \"fp-*\": [cfgsrv_credential, vultr_credential, github_token], \"cm-*\": [do_credential, vultr_credential, cfgsrv_credential]}" > top.sls '
-            ' && sudo mv salt.sls global.sls top.sls do_credential.sls vultr_credential.sls cfgsrv_credential.sls github_token.sls $(hostname).sls /srv/pillar/ '
+            ' && echo "loggly_token: %s" > loggly_token.sls'
+            r' && echo "base: {\"*\": [salt, global], \"fp-*\": [cfgsrv_credential, vultr_credential, github_token, loggly_token], \"cm-*\": [do_credential, vultr_credential, cfgsrv_credential]}" > top.sls '
+            ' && sudo mv salt.sls global.sls top.sls do_credential.sls vultr_credential.sls cfgsrv_credential.sls github_token.sls loggly_token.sls $(hostname).sls /srv/pillar/ '
             ' && sudo chown -R root:root /srv/pillar '
             ' && sudo chmod -R 600 /srv/pillar '
             ) % (config.salt_version,
@@ -120,7 +122,8 @@ def upload_pillars():
                  vultr_apikey,
                  cfgsrv_token,
                  cfgsrv_redis_url,
-                 github_token))
+                 github_token,
+                 loggly_token))
 
 if __name__ == '__main__':
     check_master_if_in_production()

--- a/bin/util.py
+++ b/bin/util.py
@@ -31,6 +31,11 @@ def read_github_token():
     return secrets_from_yaml(['github.md'],
                              ['repo-token'])[0]
 
+@memoized
+def read_loggly_token():
+    return secrets_from_yaml(['loggly.txt'],
+                             ['bravenewsoft.loggly.com'])[0]['token']
+
 def secrets_from_yaml(path, keys):
     d = yaml.load(file(os.path.join(here.secrets_path, *path)))
     return map(d.get, keys)

--- a/salt/http_proxy/http-proxy.conf
+++ b/salt/http_proxy/http-proxy.conf
@@ -33,4 +33,4 @@ chdir /home/lantern
 limit nofile 1024768 1024768
 
 # Start the process, piping output prepended with a prefix to syslog
-exec /home/lantern/http-proxy -https -addr={{ external_ip }}:62443 -key=/home/lantern/key.pem -cert=/home/lantern/cert.pem -token={{ auth_token }} -logglytoken={{ loggly_token }} | logger -t http-proxy
+exec /home/lantern/http-proxy -https -addr={{ external_ip }}:62443 -key=/home/lantern/key.pem -cert=/home/lantern/cert.pem -token={{ auth_token }} -logglytoken={{ pillar['loggly_token'] }} | logger -t http-proxy

--- a/salt/http_proxy/http-proxy.conf
+++ b/salt/http_proxy/http-proxy.conf
@@ -33,4 +33,4 @@ chdir /home/lantern
 limit nofile 1024768 1024768
 
 # Start the process, piping output prepended with a prefix to syslog
-exec /home/lantern/http-proxy -https -addr={{ external_ip }}:62443 -key=/home/lantern/key.pem -cert=/home/lantern/cert.pem -token={{ auth_token }} | logger -t http-proxy
+exec /home/lantern/http-proxy -https -addr={{ external_ip }}:62443 -key=/home/lantern/key.pem -cert=/home/lantern/cert.pem -token={{ auth_token }} -logglytoken={{ loggly_token }} | logger -t http-proxy

--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -1,6 +1,7 @@
 {% set fallback_json_file='/home/lantern/fallback.json' %}
 {% set proxy_protocol=pillar.get('proxy_protocol', 'tcp') %}
 {% set auth_token=pillar.get('auth_token') %}
+{% set loggly_token=pillar.get('loggly_token') %}
 {% set proxy_port=grains.get('proxy_port', 62443) %}
 {% set traffic_check_period_minutes=60 %}
 {% from 'ip.sls' import external_ip %}
@@ -46,6 +47,7 @@ include:
         - template: jinja
         - context:
             auth_token: {{ auth_token }}
+            loggly_token: {{ loggly_token }}
             external_ip: {{ external_ip(grains) }}
             traffic_check_period_minutes: {{ traffic_check_period_minutes }}
         - user: {{ user }}

--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -1,7 +1,6 @@
 {% set fallback_json_file='/home/lantern/fallback.json' %}
 {% set proxy_protocol=pillar.get('proxy_protocol', 'tcp') %}
 {% set auth_token=pillar.get('auth_token') %}
-{% set loggly_token=pillar.get('loggly_token') %}
 {% set proxy_port=grains.get('proxy_port', 62443) %}
 {% set traffic_check_period_minutes=60 %}
 {% from 'ip.sls' import external_ip %}
@@ -47,7 +46,6 @@ include:
         - template: jinja
         - context:
             auth_token: {{ auth_token }}
-            loggly_token: {{ loggly_token }}
             external_ip: {{ external_ip(grains) }}
             traffic_check_period_minutes: {{ traffic_check_period_minutes }}
         - user: {{ user }}


### PR DESCRIPTION
http-proxy already has `-logglytoken` option, this PR supply our own token when running it.