### PR TITLE
upgrade http-proxy to v0.0.5

### DIFF
--- a/salt/http_proxy/install_http_proxy.py
+++ b/salt/http_proxy/install_http_proxy.py
@@ -5,7 +5,7 @@ import stat
 import requests
 
 GH_TOKEN = "{{ pillar['github_token'] }}"
-VERSION = 'v0.0.4'
+VERSION = 'v0.0.5'
 
 url = 'https://api.github.com/repos/getlantern/http-proxy-lantern/releases/tags/' + VERSION
 headers = {


### PR DESCRIPTION
I tested by running `sudo salt "*" state.highstate` from cm-vltok1fffw. It updates correctly. Run Lantern valencia with fp-vltok1fffw-20151121-002 for a while and found no issue. Especially, http://photobucket.com/ and http://zh.moegirl.org/%E4%B8%9C%E6%96%B9Project render correctly.

@uaalto do you have any objection to deploy new version?