### PR TITLE
stop http-proxy before updating its binary

### DIFF
--- a/salt/http_proxy/install_http_proxy.py
+++ b/salt/http_proxy/install_http_proxy.py
@@ -25,8 +25,13 @@ if(r.ok):
             for chunk in r.iter_content(chunk_size=1048576):
                 if chunk:
                     f.write(chunk)
+        os.chmod('http-proxy-temp', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        # We have noticed some errors, which may have to do with the binary
+        # being updated while the service is running.
+        os.system('sudo service http-proxy stop')
         os.rename('http-proxy-temp', 'http-proxy')
-        os.chmod('http-proxy', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        # We don't (re)start the service again here because it has other
+        # dependencies; the salt configuration will take care of that.
         print 'Downloaded ' + download_url
     else:
         r.raise_for_status()

--- a/salt/http_proxy/install_http_proxy.py
+++ b/salt/http_proxy/install_http_proxy.py
@@ -26,12 +26,14 @@ if(r.ok):
                 if chunk:
                     f.write(chunk)
         os.chmod('http-proxy-temp', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        # We have noticed some errors, which may have to do with the binary
-        # being updated while the service is running.
-        os.system('sudo service http-proxy stop')
+        # We have noticed 'text file busy' errors trying to restart the
+        # http-proxy service, which may have to do with the binary being
+        # updated while the service is running. According to [1], unlinking the
+        # executable before replacing it should fix that.
+        #
+        # [1] http://stackoverflow.com/questions/1712033/replacing-a-running-executable-in-linux
+        os.unlink('http-proxy')
         os.rename('http-proxy-temp', 'http-proxy')
-        # We don't (re)start the service again here because it has other
-        # dependencies; the salt configuration will take care of that.
         print 'Downloaded ' + download_url
     else:
         r.raise_for_status()


### PR DESCRIPTION
Occasionally, we get `text file busy` errors when trying to start the http-proxy service.  I've noticed this once after upgrading the http-proxy-lantern release.  I suspect there's something dangerous about updating the binary of a service while it's running.  I remember we used to stop the old (flashlight, peerscanner, ...) services before updating them, for this reason.