### PR TITLE
Country specific req stats

### DIFF
--- a/lib/retire_blocked_ips_cache.py
+++ b/lib/retire_blocked_ips_cache.py
@@ -22,9 +22,9 @@ def all_vpss(provider):
     return ret
 
 @misc_util.memoized
-def requests(which):
-    print "Fetching %s requests..." % which
-    ret = redis_shell.hgetall(which + '-requests')
+def requests(which, country):
+    print "Fetching %s requests for countries %s..." % (which, country)
+    ret = redis_shell.hgetall("%s:%s-requests" % (country, which))
     print "...done fetching %s requests." % which
     print
     ret = {k: int(v) for k, v in ret.iteritems()}

--- a/lib/retire_blocked_ips_cache.py
+++ b/lib/retire_blocked_ips_cache.py
@@ -23,7 +23,7 @@ def all_vpss(provider):
 
 @misc_util.memoized
 def requests(which, country):
-    print "Fetching %s requests for countries %s..." % (which, country)
+    print "Fetching %s requests for country '%s'..." % (which, country)
     ret = redis_shell.hgetall("%s:%s-requests" % (country, which))
     print "...done fetching %s requests." % which
     print


### PR DESCRIPTION
Updates to the caching code used by retire_blocked_ips, to support country-specific request stats.

Also sneaked in: retry some 10 times when Vultr server_list(None) returns the empty list.