### PR TITLE
save last week's load_avg/CPU/mem/network/... stats once a minute

### DIFF
--- a/salt/base_prereqs.sls
+++ b/salt/base_prereqs.sls
@@ -20,6 +20,7 @@ base-packages:
             - git
             - mailutils
             - debconf-utils
+            - python-psutil
         - reload_modules: yes
 
 /usr/local/lib/pylib:

--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -106,8 +106,6 @@ requests:
 
 {% if pillar['in_production'] %}
 
-python-psutil:
-    pkg.installed
 
 uptime:
     pip.installed
@@ -121,7 +119,6 @@ uptime:
         - pip: requests
         - pip: uptime
         - pkg: python-redis
-        - pkg: python-psutil
 
 "/home/lantern/check_traffic.py 2>&1 | logger -t check_traffic":
   cron.absent:
@@ -131,7 +128,6 @@ uptime:
 #    - user: lantern
 #    - require:
 #        - file: /home/lantern/check_traffic.py
-#        - pip: psutil
 
 {% if pillar['datacenter'].startswith('vl') %}
 

--- a/salt/stats/init.sls
+++ b/salt/stats/init.sls
@@ -1,0 +1,11 @@
+/usr/bin/save_stats.py:
+  file.managed:
+    - source: salt://stats/save_stats.py
+    - user: root
+    - group: root
+    - mode: 755
+
+'/usr/bin/save_stats.py 2>&1 | logger -t save_stats':
+  cron.present:
+    - identifier: save_stats
+    - user: lantern

--- a/salt/stats/save_stats.py
+++ b/salt/stats/save_stats.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from datetime import datetime
+import os
+
+import psutil
+
+
+num_samples = 60 * 24 * 7  # keep last week, assuming 1m precision
+
+path = "/home/lantern/stats"
+
+
+def run():
+    now = datetime.utcnow()
+    la1m, _, _ = os.getloadavg()
+    net = psutil.net_io_counters(pernic=False)
+    mem = psutil.virtual_memory()
+    swap = psutil.swap_memory()
+    cpu = psutil.cpu_percent(interval=1)
+    if os.path.exists(path):
+        lines = file(path).readlines()[-num_samples:]
+    else:
+        lines = []
+    new_line = "|".join(map(str,
+        [now, la1m, cpu, mem.percent, mem.active, swap.percent, swap.sin + swap.sout,
+         net.bytes_sent, net.bytes_recv, net.errin + net.errout, net.dropin + net.dropout]))
+    print "Time | load avg 1m | CPU% | mem% | active mem | swap%% | swaptx | bytes sent | bytes recv | net errors | net drops"
+    print new_line
+    lines.append(new_line + '\n')
+    with file(path + ".tmp", 'w') as f:
+        f.writelines(lines)
+    os.rename(path + ".tmp", path)
+
+
+if __name__ == '__main__':
+    run()

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -13,6 +13,7 @@ base:
         - reboot
         - pylib
         - env
+        - stats
     'cm-vlfra1':
         - vps_sanity_checks
         - check_vpss


### PR DESCRIPTION
It's useful to have these on the VPS itself for manual inspection.  Curnently our Influx DB records data less often, keeps less of a history of it, and VPSs are more likely to be unable to hit influx for any reason than to run this cron job.