### PR TITLE
Issue85

### DIFF
--- a/salt/http_proxy/http-proxy.conf
+++ b/salt/http_proxy/http-proxy.conf
@@ -33,4 +33,4 @@ chdir /home/lantern
 limit nofile 1024768 1024768
 
 # Start the process, piping output prepended with a prefix to syslog
-exec /home/lantern/http-proxy -config /home/lantern/config.ini | logger -t http-proxy
+exec /home/lantern/http-proxy -config /home/lantern/config.ini 2>&1 | logger -t http-proxy

--- a/salt/logrotate/init.sls
+++ b/salt/logrotate/init.sls
@@ -1,0 +1,15 @@
+/etc/cron.daily/logrotate:
+  file.absent
+
+/etc/cron.hourly/logrotate:
+  file.managed:
+    - source: salt://logrotate/logrotate.cron
+    - mode: 755
+
+/etc/logrotate.d/rsyslog:
+  file.managed:
+    - source: salt://logrotate/rsyslog
+
+/etc/logrotate.d/upstart:
+  file.managed:
+    - source: salt://logrotate/upstart

--- a/salt/logrotate/logrotate.cron
+++ b/salt/logrotate/logrotate.cron
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Clean non existent log file entries from status file
+cd /var/lib/logrotate
+test -e status || touch status
+head -1 status > status.clean
+sed 's/"//g' status | while read logfile date
+do
+    [ -e "$logfile" ] && echo "\"$logfile\" $date"
+done >> status.clean
+mv status.clean status
+
+test -x /usr/sbin/logrotate || exit 0
+/usr/sbin/logrotate /etc/logrotate.conf

--- a/salt/logrotate/rsyslog
+++ b/salt/logrotate/rsyslog
@@ -1,0 +1,37 @@
+/var/log/syslog
+{
+        rotate 10
+        size 100M
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                reload rsyslog >/dev/null 2>&1 || true
+        endscript
+}
+
+/var/log/mail.info
+/var/log/mail.warn
+/var/log/mail.err
+/var/log/mail.log
+/var/log/daemon.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/lpr.log
+/var/log/cron.log
+/var/log/debug
+/var/log/messages
+{
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                reload rsyslog >/dev/null 2>&1 || true
+        endscript
+}

--- a/salt/logrotate/rsyslog
+++ b/salt/logrotate/rsyslog
@@ -1,7 +1,7 @@
 /var/log/syslog
 {
-        rotate 10
-        size 100M
+        rotate 5
+        size 200M
         missingok
         notifempty
         delaycompress

--- a/salt/logrotate/upstart
+++ b/salt/logrotate/upstart
@@ -14,7 +14,6 @@
 /var/log/upstart/http-proxy.log {
         rotate 5
         size 200M
-        daily
         missingok
         compress
         notifempty

--- a/salt/logrotate/upstart
+++ b/salt/logrotate/upstart
@@ -12,8 +12,8 @@
 # general one because according to the logrotate man page "latter definitions
 # override earlier ones".
 /var/log/upstart/http-proxy.log {
-        rotate 10
-        size 100M
+        rotate 5
+        size 200M
         daily
         missingok
         compress

--- a/salt/logrotate/upstart
+++ b/salt/logrotate/upstart
@@ -1,0 +1,22 @@
+/var/log/upstart/*.log {
+        rotate 4
+        daily
+        missingok
+        compress
+        notifempty
+        nocreate
+}
+
+# We used to get all stderr here. That shouldn't be true anymore, but it can't
+# hurt to limit the size of these just in case... This goes after the more
+# general one because according to the logrotate man page "latter definitions
+# override earlier ones".
+/var/log/upstart/http-proxy.log {
+        rotate 10
+        size 100M
+        daily
+        missingok
+        compress
+        notifempty
+        nocreate
+}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -14,6 +14,7 @@ base:
         - pylib
         - env
         - stats
+        - logrotate
     'cm-vlfra1':
         - vps_sanity_checks
         - check_vpss


### PR DESCRIPTION
Also redirect stderr to stdin, so all go to syslog.  Just in case, limit the size of /var/log/upstart/http-proxy.log, which is where stderr used to go.

I tested this vs a script that spammed syslog in a test cloudmaster.  A caveat: logs will not be trimmed when rotated, so we'll keep the whole logs of the latest 5h no matter what. 