### PR TITLE
move 'etc' to donyc3, assign its current cloudmasters to 'ir'

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -6,11 +6,12 @@ import here
 
 # Values for production deployment.
 salt_version = 'v2015.5.5'
-production_cloudmasters = ['cm-doams3', 'cm-dosgp1', 'cm-vltok1', 'cm-vlfra1', 'cm-vlpar1']
+production_cloudmasters = ['cm-doams3', 'cm-dosgp1', 'cm-donyc3', 'cm-vltok1', 'cm-vlfra1', 'cm-vlpar1']
 datacenter = os.getenv("DC", 'doams3')
 cloudmaster_name = 'cm-' + datacenter
 cloudmaster_address = {'doams3':  '188.166.35.238',
                        'dosgp1': '128.199.84.79',
+                       'donyc3': '159.203.73.43',
                        'vltok1': '45.32.47.4',
                        'vlfra1': '45.63.116.130',
                        'vlpar1': '104.238.188.202'}[datacenter]

--- a/lib/fetchcfg.py
+++ b/lib/fetchcfg.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
         region = args[1]
     if not rs.sismember('user-regions', region):
         print "Usage: %s [--json] [--print-name-and-ip] [user-region]" % args[0]
-        print "Where region must be one of 'sea' for Southeast Asia (currently, only China) or 'etc' (default) for anywhere else."
+        print "Where region must be one of 'sea' for Southeast Asia (currently, only China) 'ir' for Iran, or 'etc' (default) for anywhere else."
         print "Options (all default to false):"
         print "    --json: output a format that can be directly read by genconfig."
         print "    --print-name-and-ip: print name and ip of the new proxy, in addition to its config."

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -219,9 +219,10 @@ def dc_by_cm(cm):
     assert ret in _region_by_production_cm
     return ret
 
-_region_by_production_cm = {'doams3': 'etc',
-                            'vlfra1': 'etc',
-                            'vlpar1': 'etc',
+_region_by_production_cm = {'donyc3': 'etc',
+                            'doams3': 'ir',
+                            'vlfra1': 'ir',
+                            'vlpar1': 'ir',
                             'dosgp1': 'sea',
                             'vltok1': 'sea'}
 def region_by_dc(dc):

--- a/salt/check_vpss/check_vpss.py
+++ b/salt/check_vpss/check_vpss.py
@@ -23,7 +23,7 @@ def in_production(name):
     return (not name.startswith('fp-')
             or vps_util.cm_by_name(name) in ['doams3', 'dosgp1'])
 
-expected_do = vpss_from_cm('doams3') | vpss_from_cm('dosgp1')
+expected_do = vpss_from_cm('doams3') | vpss_from_cm('dosgp1') | vpss_from_cm('donyc3')
 expected_vultr = vpss_from_cm('vltok1') | vpss_from_cm('vlfra1') | vpss_from_cm('vlpar1')
 
 actual_do = set(v.name for v in vps_util.vps_shell('do').all_vpss()

--- a/salt/cloudmaster/init.sls
+++ b/salt/cloudmaster/init.sls
@@ -31,7 +31,7 @@ sshpass:
 
 {% if pillar['in_production']
       and (svc != 'refill_srvq'
-           or pillar['cloudmaster_name'] in ['cm-dosgp1', 'cm-vlpar1']) %}
+           or pillar['cloudmaster_name'] in ['cm-donyc3', 'cm-dosgp1', 'cm-vlpar1']) %}
 
 /etc/init/{{ svc }}.conf:
     file.managed:


### PR DESCRIPTION
The transition plan is:

 - shut down all services in existing cloudmasters
 - back up the redis DB
 - run a script to transition the redis DB
 - deploy this to all cloudmasters (this restarts services with the new config)