### PR TITLE
update http-proxy to v0.0.13

### DIFF
--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -3,9 +3,9 @@
 {% set auth_token=pillar.get('auth_token') %}
 {% set proxy_port=grains.get('proxy_port', 62443) %}
 {% set traffic_check_period_minutes=60 %}
-{% set http_proxy_version ='v0.0.12' %}
+{% set http_proxy_version ='v0.0.13' %}
 # Be sure to also update sha (`shasum http-proxy`) when you bump up version
-{% set http_proxy_sha='e16eb549b0f5b6e9951a18e278550a8132389c69' %}
+{% set http_proxy_sha='9c590861d9546386ed4b211270f07a4734563888' %}
 {% from 'ip.sls' import external_ip %}
 
 fp-dirs:


### PR DESCRIPTION
Fixed an issue sending X-Lantern-Config-Client-IP header
Use Go's default cipher suites in tlsdefaults
Built with Go 1.5.3

Tested salt deployment on fp-vltok1fffw-20151121-002.

@aranhoide Do you think it's okay to deploy another round in production? I can also run the deployment with your instructions.