### PR TITLE
Issue112

### DIFF
--- a/bin/util.py
+++ b/bin/util.py
@@ -11,6 +11,9 @@ from misc_util import memoized
 def in_production():
     return config.cloudmaster_name in config.production_cloudmasters
 
+def in_staging():
+    return config.cloudmaster_name.endswith('staging')
+
 @memoized
 def read_do_credential():
     return secrets_from_yaml(['lantern_aws', 'do_credential'],
@@ -40,6 +43,11 @@ def read_loggly_token():
 def read_slack_webhook_url():
     return secrets_from_yaml(['lantern_aws', 'slack.yaml'],
                              ['webhook_url'])[0]
+
+@memoized
+def read_slack_staging_webhook_url():
+    return secrets_from_yaml(['lantern_aws', 'slack.yaml'],
+                             ['staging_webhook_url'])[0]
 
 def secrets_from_yaml(path, keys):
     d = yaml.load(file(os.path.join(here.secrets_path, *path)))

--- a/salt/check_vpss/check_vpss.py
+++ b/salt/check_vpss/check_vpss.py
@@ -19,15 +19,11 @@ def vpss_from_cm(cm):
         file(cm + '_vpss_version', 'w').write(remote_version)
         return set(ret)
 
-def in_production(name):
-    return (not name.startswith('fp-')
-            or vps_util.cm_by_name(name) in ['doams3', 'dosgp1', 'donyc3'])
-
 expected_do = vpss_from_cm('doams3') | vpss_from_cm('dosgp1') | vpss_from_cm('donyc3')
 expected_vultr = vpss_from_cm('vltok1') | vpss_from_cm('vlfra1') | vpss_from_cm('vlpar1')
 
 actual_do = set(v.name for v in vps_util.vps_shell('do').all_vpss()
-                if in_production(v.name))
+                if vps_util.is_production_proxy(v.name))
 actual_vultr = set(v.name for v in vps_util.vps_shell('vl').all_vpss())
 
 errors = []

--- a/salt/checkfallbacks/init.sls
+++ b/salt/checkfallbacks/init.sls
@@ -12,7 +12,7 @@
     - mode: 755
 
 "/usr/bin/checkfallbacks.py | logger -t checkfallbacks":
-{% if pillar['in_production'] %}
+{% if pillar['in_production'] or pillar['in_staging'] %}
   cron.present:
     - minute: '*/11'
     - user: lantern

--- a/salt/cloudmaster/refill_cm_srvq.conf
+++ b/salt/cloudmaster/refill_cm_srvq.conf
@@ -1,0 +1,54 @@
+# refill_srvq - upstart job file
+
+description "refill_srvq"
+author "<aranhoide@getlantern.org>"
+
+# Stanzas
+#
+# Stanzas control when and how a process is started and stopped
+# See a list of stanzas here: http://upstart.ubuntu.com/wiki/Stanzas#respawn
+
+# When to start the service
+start on runlevel [2345]
+
+# When to stop the service
+stop on runlevel [016]
+
+# Automatically restart process if crashed
+respawn
+
+# Terminate with SIGINT instead of SIGKILL
+kill signal SIGINT
+
+# Wait 15 seconds before sending SIGKILL if SIGINT doesn't work
+kill timeout 15
+
+# Run as root
+setuid root
+
+# Run in lantern's home directory
+chdir /home/lantern
+
+# We've observed we need to raise the limit on open file descriptors
+limit nofile 1024768 1024768
+
+# Set environment variables for configuration and authentication
+env CM="{{ pillar['cloudmaster_name'] }}"
+export CM
+env DO_TOKEN="{{ pillar['do_token'] }}"
+export DO_TOKEN
+env VULTR_APIKEY="{{ pillar['vultr_apikey'] }}"
+export VULTR_APIKEY
+env REDIS_URL="{{ pillar['cfgsrv_redis_url'] }}"
+export REDIS_URL
+env PYTHONPATH="/usr/local/lib/pylib"
+export PYTHONPATH
+env SLACK_WEBHOOK_URL="{{ pillar['slack_webhook_url'] }}"
+export SLACK_WEBHOOK_URL
+env MAXPROCS=10
+export MAXPROCS
+env QSCOPE="CM"
+export QSCOPE
+
+# Start the process, piping output prepended with a prefix to syslog
+exec /usr/bin/refill_srvq.py 2>&1 | logger -t refill_srvq

--- a/salt/cloudmaster/refill_region_srvq.conf
+++ b/salt/cloudmaster/refill_region_srvq.conf
@@ -47,6 +47,8 @@ env SLACK_WEBHOOK_URL="{{ pillar['slack_webhook_url'] }}"
 export SLACK_WEBHOOK_URL
 env MAXPROCS=10
 export MAXPROCS
+env QSCOPE="REGION"
+export QSCOPE
 
 # Start the process, piping output prepended with a prefix to syslog
 exec /usr/bin/refill_srvq.py 2>&1 | logger -t refill_srvq

--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -107,7 +107,7 @@ requests:
         - user: lantern
 
 
-{% if pillar['in_production'] %}
+{% if pillar['in_production'] or pillar['in_staging'] %}
 
 
 uptime:


### PR DESCRIPTION
Have per-cloudmaster server request queues and server queues, fixes #112.

Also make the staging condition more visible across the deployment, mostly to make it more like a production setup.  Staging gets more services enabled than a plain test setup, and gets a dedicated slack channel for alerts.