### PR TITLE
[don't merge] Publish IPv6 address(es) in config

### DIFF
--- a/lib/alert.py
+++ b/lib/alert.py
@@ -6,8 +6,8 @@ import requests
 
 
 instance_id = "{{ grains['id'] }}"
-# {% from 'ip.sls' import external_ip %}
-ip = "{{ external_ip(grains) }}"
+# {% from 'ip.sls' import external_ipv4 %}
+ip = "{{ external_ipv4(grains) }}"
 url = os.environ.get('SLACK_WEBHOOK_URL')
 
 

--- a/lib/vultr_util.py
+++ b/lib/vultr_util.py
@@ -33,8 +33,8 @@ default_plan = {'vltok1': u'31',
 def ssh_tmpl(ssh_cmd):
     return "ssh -i /etc/salt/cloudmaster.id_rsa -o StrictHostKeyChecking=no root@%s " + ("'%s'" % ssh_cmd)
 
-#{% from 'ip.sls' import external_ip %}
-bootstrap_tmpl = ssh_tmpl("curl -L https://bootstrap.saltstack.com | sh -s -- -X -A {{ external_ip(grains) }} -i %s git {{ pillar['salt_version'] }}")
+#{% from 'ip.sls' import external_ipv4 %}
+bootstrap_tmpl = ssh_tmpl("curl -L https://bootstrap.saltstack.com | sh -s -- -X -A {{ external_ipv4(grains) }} -i %s git {{ pillar['salt_version'] }}")
 
 scpkeys_tmpl = "scp -p -C -i /etc/salt/cloudmaster.id_rsa -o StrictHostKeyChecking=no minion.pem minion.pub root@%s:/etc/salt/pki/minion/"
 

--- a/salt/http_proxy/config.ini
+++ b/salt/http_proxy/config.ini
@@ -1,8 +1,8 @@
 {% if obfs4_port != 0 %}
-obfs4-addr = {{ external_ip }}:{{ obfs4_port }}
+obfs4-addr = {{ external_ipv4 }}:{{ obfs4_port }}
 obfs4-dir = /home/lantern/
 {% else %}
-addr = {{ external_ip }}:{{ proxy_port }}
+addr = {{ external_ipv4 }}:{{ proxy_port }}
 {% endif %}
 key = /home/lantern/key.pem
 cert = /home/lantern/cert.pem

--- a/salt/http_proxy/fallback.json
+++ b/salt/http_proxy/fallback.json
@@ -1,4 +1,5 @@
-{"ip" : "{{ external_ip }}",
+{"ip" : "{{ external_ipv4 }}",
+ "ipv6": "{{ external_ipv6 }}",
  "port" : "443",
  "auth_token" : "{{ auth_token }}",
  "protocol" : "tcp"

--- a/salt/http_proxy/gencert.py
+++ b/salt/http_proxy/gencert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-{% from 'ip.sls' import external_ip %}
+{% from 'ip.sls' import external_ipv4 %}
 
 import os
 from random import SystemRandom
@@ -90,7 +90,7 @@ def gen_cert_call():
 
     argstr = " ".join("-%s %s" % (key, val) for key, val in args.iteritems())
     # DRY: org.lantern.proxy.CertTrackingSslEngineSource in the client.
-    return "keytool -genkeypair -alias fallback -keypass 'Be Your Own Lantern' -storepass 'Be Your Own Lantern' -keystore /home/lantern/littleproxy_keystore.jks -ext san=ip:{{ external_ip(grains) }} " + argstr
+    return "keytool -genkeypair -alias fallback -keypass 'Be Your Own Lantern' -storepass 'Be Your Own Lantern' -keystore /home/lantern/littleproxy_keystore.jks -ext san=ip:{{ external_ipv4(grains) }} " + argstr
 
 
 if __name__ == '__main__':

--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -7,7 +7,7 @@
 {% set http_proxy_version ='obfs4test' %}
 # Be sure to also update sha (`shasum http-proxy`) when you bump up version
 {% set http_proxy_sha='1cc621f48358a6df44e9bf462382918300339fd4' %}
-{% from 'ip.sls' import external_ip %}
+{% from 'ip.sls' import external_ipv4 %}
 
 fp-dirs:
   file.directory:
@@ -51,7 +51,8 @@ include:
         - template: jinja
         - context:
             auth_token: {{ auth_token }}
-            external_ip: {{ external_ip(grains) }}
+            external_ipv4: {{ external_ipv4(grains) }}
+            external_ipv6: {{ external_ipv6(grains) }}
             proxy_port: {{ proxy_port }}
             obfs4_port: {{ obfs4_port }}
             traffic_check_period_minutes: {{ traffic_check_period_minutes }}

--- a/salt/http_proxy/save_access_data.py
+++ b/salt/http_proxy/save_access_data.py
@@ -21,7 +21,7 @@ def log_exceptions(f):
 def save_access_data():
     d_in = json.load(file('{{ fallback_json_file }}'))
     d_out = {'addr': '%s:%s' % (d_in['ipv4'], d_in['port']),
-             'ipv6': d_in['ipv6'],
+             'v6addr': '[%s]:%s' % (d_in['ipv6'], d_in['port']),
              'authtoken': d_in['auth_token']}
 
     {% if obfs4_port != 0 %}

--- a/salt/http_proxy/save_access_data.py
+++ b/salt/http_proxy/save_access_data.py
@@ -24,15 +24,17 @@ def save_access_data():
     d_out = {'addr': '%s:%s' % (d_in['ipv4'], d_in['port']),
              'authtoken': d_in['auth_token']}
 
+    # While we currently use at most one IPv6 address per proxy, our providers
+    # allow us to use any in a range of addresses, which might come useful some
+    # day. So let's return a list to be forward compatible.
+    v6addrs = []
     # At least in DO, a VPS with IPv6 disabled will still get link-local
     # addresses reported in grains. These can only cause confusion to clients
     # so let's filter them out.
     ipv6 = d_in.get('ipv6')
     if ipv6 and not ipv6.startswith('fe80'):  # link-local address prefix
-        v6addr = '[%s]:%s' % (d_in['ipv6'], d_in['port'])
-    else:
-        v6addr = ""
-    d_out['v6addr'] = v6addr
+        v6addrs.append('[%s]:%s' % (d_in['ipv6'], d_in['port']))
+    d_out['v6addrs'] = v6addrs
 
     {% if obfs4_port != 0 %}
     add_obfs4_access_data(d_out)

--- a/salt/http_proxy/save_access_data.py
+++ b/salt/http_proxy/save_access_data.py
@@ -20,6 +20,7 @@ def log_exceptions(f):
 @log_exceptions
 def save_access_data():
     d_in = json.load(file('{{ fallback_json_file }}'))
+    # we call this 'addr' and not 'v4addr' for backwards compatibility reasons.
     d_out = {'addr': '%s:%s' % (d_in['ipv4'], d_in['port']),
              'v6addr': '[%s]:%s' % (d_in['ipv6'], d_in['port']),
              'authtoken': d_in['auth_token']}

--- a/salt/http_proxy/save_access_data.py
+++ b/salt/http_proxy/save_access_data.py
@@ -22,8 +22,17 @@ def save_access_data():
     d_in = json.load(file('{{ fallback_json_file }}'))
     # we call this 'addr' and not 'v4addr' for backwards compatibility reasons.
     d_out = {'addr': '%s:%s' % (d_in['ipv4'], d_in['port']),
-             'v6addr': '[%s]:%s' % (d_in['ipv6'], d_in['port']),
              'authtoken': d_in['auth_token']}
+
+    # At least in DO, a VPS with IPv6 disabled will still get link-local
+    # addresses reported in grains. These can only cause confusion to clients
+    # so let's filter them out.
+    ipv6 = d_in.get('ipv6')
+    if ipv6 and not ipv6.startswith('fe80'):  # link-local address prefix
+        v6addr = '[%s]:%s' % (d_in['ipv6'], d_in['port'])
+    else:
+        v6addr = ""
+    d_out['v6addr'] = v6addr
 
     {% if obfs4_port != 0 %}
     add_obfs4_access_data(d_out)

--- a/salt/http_proxy/util.py
+++ b/salt/http_proxy/util.py
@@ -9,8 +9,8 @@ auth_token = "{{ pillar['cfgsrv_token'] }}"
 instance_id = "{{ grains['id'] }}"
 region = vps_util.region_by_name(instance_id)
 
-# {% from 'ip.sls' import external_ip %}
-ip = "{{ external_ip(grains) }}"
+# {% from 'ip.sls' import external_ipv4 %}
+ip = "{{ external_ipv4(grains) }}"
 close_flag_filename = "server_closed"
 retire_flag_filename = "server_retired"
 

--- a/salt/ip.sls
+++ b/salt/ip.sls
@@ -1,2 +1,4 @@
-{% macro external_ip(grains) %}{{ grains['ip_interfaces']['eth0'][0] }}{% endmacro %}
-{% macro internal_ip(grains) %}{{ grains['ip_interfaces']['eth1'][0] }}{% endmacro %}
+{% macro external_ipv4(grains) %}{{ grains['ip4_interfaces']['eth0'][0] }}{% endmacro %}
+{% macro internal_ipv4(grains) %}{{ grains['ip4_interfaces']['eth1'][0] }}{% endmacro %}
+{% macro external_ipv6(grains) %}{{ grains['ip6_interfaces']['eth0'][0] }}{% endmacro %}
+{% macro internal_ipv6(grains) %}{{ grains['ip6_interfaces']['eth1'][0] }}{% endmacro %}

--- a/salt/ip.sls
+++ b/salt/ip.sls
@@ -1,3 +1,7 @@
+{# It's a happy coincidence that currently in both DO and Vultr eth0 is the
+public interface and eth1 is the one for private networking. Also, public
+addresses are listed before private ones in both. We should check these
+assumptions for every new provider we add. #}
 {% macro external_ipv4(grains) %}{{ grains['ip4_interfaces']['eth0'][0] }}{% endmacro %}
 {% macro internal_ipv4(grains) %}{{ grains['ip4_interfaces']['eth1'][0] }}{% endmacro %}
 {% macro external_ipv6(grains) %}{{ grains['ip6_interfaces']['eth0'][0] }}{% endmacro %}

--- a/salt/salt_cloud/cloud
+++ b/salt/salt_cloud/cloud
@@ -1,7 +1,7 @@
-{% from 'ip.sls' import external_ip %}
+{% from 'ip.sls' import external_ipv4 %}
 
 sync_after_install: all
 delete_sshkeys: True
 minion:
-  master: {{ external_ip(grains) }}
+  master: {{ external_ipv4(grains) }}
   startup_states: highstate


### PR DESCRIPTION
Depends on https://github.com/getlantern/http-proxy-lantern/issues/48 and https://github.com/getlantern/lantern_aws/issues/124.  **Don't merge** before those are resolved.

Note that as of this writing all new proxies are created with IPv6 enabled.  That was already true for Vultr, and I've made it so earlier today for DO.  This PR is only about feeding that info to the config that proxies publish for the clients' benefit.

Currently only one address is added, but we could conceivably add more in the future.  In any case, the client may forward-compatibly choose to use them all, only the first one, or none.

I've tested this in both DO and Vultr proxies, both newly created and updated, both with and without IPv6 support.  (To be precise, I've tested the version that only publishes one address, but that particular change is trivial and vendor-independent.)