### PR TITLE
upgrade to java 8

### DIFF
--- a/salt/lantern_build_prereqs/init.sls
+++ b/salt/lantern_build_prereqs/init.sls
@@ -5,26 +5,26 @@ java-ppa:
 java-home:
     file.append:
         - name: /etc/profile
-        - text: "export JAVA_HOME=/usr/lib/jvm/java-7-oracle"
+        - text: "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
 
 accept-oracle-terms:
     cmd.run:
-        - name: "echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections"
+        - name: "echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections"
         - user: root
 
 java:
     pkg.installed:
         - order: 2
         - names:
-            - oracle-java7-installer
-            - oracle-java7-set-default
+            - oracle-java8-installer
+            - oracle-java8-set-default
         - require:
             - pkgrepo: java-ppa
             - file: java-home
             - cmd: accept-oracle-terms
     cmd.run:
         - order: 2
-        - name: "update-java-alternatives -s java-7-oracle"
+        - name: "update-java-alternatives -s java-8-oracle"
         - user: root
         - require:
             - pkg: java


### PR DESCRIPTION
The only thing for which we're currently using Java is for generating certs in proxies.  I have launched a new proxy from this branch and it passed the checkfallbacks test.

The main impetus for this is that Java 8 makes building ops-panel easier.  I'm getting [permgen errors](https://github.com/boot-clj/boot/wiki/JVM-Options#permgen-errors-java-7) while doing this.  While there are workarounds for that, it seems simplest to just upgrade to a Java version without this problem. 