### PR TITLE
Added support for launching obfs4 proxies from srvreqq (incompatible with current configserver)

### DIFF
--- a/lib/do_util.py
+++ b/lib/do_util.py
@@ -18,8 +18,8 @@ do_token = os.getenv("DO_TOKEN")
 do = digitalocean.Manager(token=do_token)
 
 
-def create_vps(name):
-    vps_util.save_pillar(name)
+def create_vps(name, req):
+    vps_util.save_pillar(name, req)
     plan = vps_util.dc_by_cm(vps_util.my_cm()) + "_512MB"
     out = subprocess.check_output(["salt-cloud", "-p", plan, name])
     # Uberhack: XXX update with salt version...

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -209,7 +209,9 @@ def cm_by_name(name):
     elif name.startswith('fp-jp-'):
         name = name.replace('jp', 'vltok1', 1)
 
-    return name.split('-')[1]
+    # We need to count from the right because we have HTTPS proxies both with
+    # and without the -https- part in their name.
+    return name.split('-')[-3]
 
 def region_by_name(name):
     return region_by_dc(dc_by_name(name))

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -22,6 +22,7 @@ auth_token: %s
 install-from: git
 instance_id: %s
 proxy_protocol: tcp
+obfs4_port: %s
 """
 
 auth_token_alphabet = string.ascii_letters + string.digits
@@ -44,9 +45,10 @@ def random_auth_token():
     return ''.join(random.choice(auth_token_alphabet)
                    for _ in xrange(auth_token_length))
 
-def save_pillar(name):
+def save_pillar(name, req):
+    obfs4_port = req.get('obfs4_port', 0)
     with file("/srv/pillar/%s.sls" % name, 'w') as f:
-        f.write(pillar_tmpl % (random_auth_token(), name))
+        f.write(pillar_tmpl % (random_auth_token(), name, obfs4_port))
 
 def trycmd(cmd, tries=sys.maxsize):
     for x in xrange(tries):
@@ -226,7 +228,8 @@ _region_by_production_cm = {'donyc3': 'etc',
                             'vlpar1': 'ir',
                             'dosgp1': 'sea',
                             'dosfo1': 'sea',
-                            'vltok1': 'sea'}
+                            'vltok1': 'sea',
+                            'vllan1': 'etc',}
 def region_by_dc(dc):
     return _region_by_production_cm[dc]
 

--- a/lib/vultr_util.py
+++ b/lib/vultr_util.py
@@ -23,11 +23,13 @@ cloudmaster_keyid = u'56aa5453eef0b'
 
 vultr_dcid = {'vltok1': u'25',
               'vlfra1': u'9',
-              'vlpar1': u'24'}
+              'vlpar1': u'24',
+              'vllan1': u'5',}
 
 default_plan = {'vltok1': u'31',
                 'vlfra1': u'29',
-                'vlpar1': u'29'}
+                'vlpar1': u'29',
+                'vllan1': u'29',}
 
 # XXX: feed cloudmaster's internal IP when we launch one in Tokyo.
 def ssh_tmpl(ssh_cmd):
@@ -59,7 +61,8 @@ def minion_id(prefix, n):
         datetime.now().date().isoformat().replace('-', ''),
         str(n).zfill(3))
 
-def create_vps(label):
+def create_vps(label, req):
+    vps_util.save_pillar(label, req)
     dc = vps_util.dc_by_cm(vps_util.my_cm())
     subid = vultr.server_create(vultr_dcid[dc],
                                 default_plan[dc],
@@ -130,7 +133,6 @@ def init_vps(d):
         os.rename('minion.pub', os.path.join('/etc/salt/pki/master/minions', name))
         print("Starting salt-minion...")
         trycmd(start_tmpl % ip)
-        vps_util.save_pillar(name)
         print("Calling highstate...")
         time.sleep(10)
         trycmd("salt -t 1800 %s state.highstate" % name)

--- a/salt/checkfallbacks/init.sls
+++ b/salt/checkfallbacks/init.sls
@@ -1,7 +1,7 @@
 {% from 'install_from_release.sls' import install_from_release %}
 
 {# define cmd: checkfallbacks-installed #}
-{{ install_from_release('checkfallbacks', '0.0.23') }}
+{{ install_from_release('checkfallbacks', '2.1.1') }}
 
 /usr/bin/checkfallbacks.py:
   file.managed:


### PR DESCRIPTION
This requires a new request format.  Instead of requesting just a number, this now takes a JSON data structure with the following parameters:

```
{
    "id": 6,
    "obfs4_port": 62443,
    "srvq": "donyc3ox:srvq:manual",
}
```

id - this is the same as the number that we used to send.
obfs4_port - optional port for launching an obfs4 proxy instead of an https proxy.  This should always be 62443.
srvq - the queue to which the successful launch response is sent.  This used to always go to the same queue, but now client can specify it.