### PR TITLE
ssh-alert doublecheck

### DIFF
--- a/lib/alert.py
+++ b/lib/alert.py
@@ -17,16 +17,19 @@ ip = "{{ external_ip(grains) }}"
 url = os.environ.get('SLACK_WEBHOOK_URL')
 
 
-def send_to_slack(title, text, color='warning'):
+def send_to_slack(title, text, color='warning', channel=None):
     text = "%s (%s) reports:\n%s" % (instance_id, ip, text)
     payload = {"fallback": title + '\n' + text,
                "color": color,
                "title": title,
                "text": text,
                "mrkdwn_in": ['text']}
+    data = {'attachments': [payload]}
+    if channel:
+        data['channel'] = channel
     requests.post(url,
                   headers={'content-type': 'application/json'},
-                  data=json.dumps({'attachments': [payload]}))
+                  data=json.dumps(data))
 
 def alert(type, details, title=None, text=None, color='warning', pipeline=None):
     """

--- a/salt/sshalert/sshalert.py
+++ b/salt/sshalert/sshalert.py
@@ -24,7 +24,6 @@ if not whitelisted:
     # test cloudmaster).  You can easily lock yourself out of the test machine.
     # Keeping a backup of this file and a separate SSH session open while you
     # test this should help prevent such lockout.
-    force = False
     if not original_cmd:
         print >> sys.stderr, "Your IP is not whitelisted.  Please use lantern_aws/bin/hussh instead."
         print >> sys.stderr, "If you continue, ssh-alert noise will ensue.  You'll need to warn the"

--- a/salt/sshalert/sshalert.py
+++ b/salt/sshalert/sshalert.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import alert
+import misc_util
 try:
     from redis_util import redis_shell
 except ImportError:
@@ -15,16 +16,48 @@ user = os.environ['USER']
 
 whitelisted = redis_shell is not None and redis_shell.exists('sshalert-whitelist:%s' % ip)
 
-if not whitelisted:
-    alert.send_to_slack("SSH login", "User %s *logging in* from IP %s" % (user, ip))
-
 original_cmd = os.getenv('SSH_ORIGINAL_COMMAND')
+
+if not whitelisted:
+    # WARNING: if you make any changes to this check or its response you better
+    # test them in a more disposable machine (e.g., a test proxy, rather than a
+    # test cloudmaster).  You can easily lock yourself out of the test machine.
+    # Keeping a backup of this file and a separate SSH session open while you
+    # test this should help prevent such lockout.
+    force = False
+    if not original_cmd:
+        print >> sys.stderr, "Your IP is not whitelisted.  Please use lantern_aws/bin/hussh instead."
+        print >> sys.stderr, "If you continue, ssh-alert noise will ensue.  You'll need to warn the"
+        print >> sys.stderr, "team about this, or somebody will have to manually check whether this"
+        print >> sys.stderr, "was a legit login."
+        force = misc_util.confirm("Continue anyway?")
+    else:
+        if original_cmd.split()[0] == '_force_':
+            force = True
+            original_cmd = original_cmd[len('_force_'):].lstrip()
+        else:
+            print >> sys.stderr, "Your IP is not whitelisted.  Please use lantern_aws/bin/hussh instead."
+            print >> sys.stderr, "If that's not possible, use _force_, e.g.:"
+            print >> sys.stderr, '\n   ssh <my-address> "_force_ %s"\n' % original_cmd
+            force = False
+    if force:
+        print >> sys.stderr, "Please leave a note about this login in #ssh-alerts (preferrably)"
+        print >> sys.stderr, "or in the dev mailing list."
+    else:
+        sys.exit(1)
+    alert.send_to_slack("SSH login",
+                        "User %s *logging in* from IP %s" % (user, ip),
+                        channel="#ssh-alerts")
+
 if original_cmd:
     ret = os.system(original_cmd)
 else:
     ret = os.system(os.environ['SHELL'])
 
 if not whitelisted:
-    alert.send_to_slack("SSH logout", "User %s from IP %s logging out" % (user, ip), color="good")
+    alert.send_to_slack("SSH logout",
+                        "User %s from IP %s logging out" % (user, ip),
+                        color="good",
+                        channel="#ssh-alerts")
 
 sys.exit(ret)


### PR DESCRIPTION
If you accidentally ssh into a proxy, you'll be prompted to use hussh instead.  You can still override this if you're in a rush to fix something or you can't set up hussh at this moment.

For interactive logins, you just get asked to confirm that you really want to log in.  For noninteractive logins, you can prepend `_force_` to bypass this check.  In either case, the script will try and shame you on that. :)

As a side feature, ssh alerts now go to a new #ssh-alert slack channel.

I've tested this in a test proxy.