### PR TITLE
remove cloudmaster's key from root's authorized keys as soon as the V…

### DIFF
--- a/bin/update.py
+++ b/bin/update.py
@@ -55,9 +55,8 @@ def rsync_salt():
     return rsync(here.salt_states_path, '/srv/salt')
 
 def scp(src, dst):
-    error = os.system("scp -o StrictHostKeyChecking=no -i %s %s root@%s:%s"
-                      % (config.key_path,
-                         src,
+    error = os.system("scp -o StrictHostKeyChecking=no %s %s:%s"
+                      % (src,
                          config.cloudmaster_address,
                          dst))
     if not error:
@@ -65,10 +64,9 @@ def scp(src, dst):
     return error
 
 def rsync(src, dst):
-    error = os.system(("rsync -e 'ssh -o StrictHostKeyChecking=no -i %s'"
-                       + " -azLk %s/ root@%s:%s")
-                      % (config.key_path,
-                         src,
+    error = os.system(("rsync -e 'ssh -o StrictHostKeyChecking=no'"
+                       + " -azLk %s/ %s:%s")
+                      % (src,
                          config.cloudmaster_address,
                          dst))
     if not error:
@@ -79,8 +77,8 @@ def upload_master_config():
     util.ssh_cloudmaster(r"""(echo "timeout: 20" """
                          + r""" && echo "keep_jobs: 2" """
                          + r""" && echo "worker_threads: 20" """
-                         + r""" ) > /root/master""")
-    move_root_file('/root/master', '/etc/salt/master')
+                         + r""" ) > master""")
+    move_root_file('master', '/etc/salt/master')
 
 def move_root_file(src, dst):
     return util.ssh_cloudmaster(('sudo mv %s %s'

--- a/bin/util.py
+++ b/bin/util.py
@@ -67,8 +67,7 @@ def set_secret_permissions():
 
 def ssh_cloudmaster(cmd=None, out=None):
     whitelist_ssh()
-    full_cmd = "ssh -o StrictHostKeyChecking=no -i %s root@%s" % (
-                    config.key_path,
+    full_cmd = "ssh -o StrictHostKeyChecking=no %s" % (
                     config.cloudmaster_address)
     if cmd:
         full_cmd += " '%s'" % cmd

--- a/lib/do_util.py
+++ b/lib/do_util.py
@@ -12,7 +12,6 @@ import vps_util
 
 
 ssh_tmpl = "ssh -o StrictHostKeyChecking=no -i /etc/salt/cloudmaster.id_rsa root@%s '%%s'"
-fetchaccessdata_tmpl = "scp -o StrictHostKeyChecking=no -i /etc/salt/cloudmaster.id_rsa root@%s:/home/lantern/access_data.json ."
 
 do_token = os.getenv("DO_TOKEN")
 do = digitalocean.Manager(token=do_token)
@@ -37,10 +36,7 @@ def init_vps(d):
         print("Highstate still running...")
         time.sleep(10)
     print("Highstate done!")
-    return vps_util.hammer_the_damn_thing_until_it_proxies(
-        name,
-        ssh_tmpl % ip,
-        fetchaccessdata_tmpl % ip)
+    return vps_util.hammer_the_damn_thing_until_it_proxies(name)
 
 def droplets_by_name():
     return {d.name: d

--- a/lib/do_util.py
+++ b/lib/do_util.py
@@ -11,8 +11,6 @@ import misc_util
 import vps_util
 
 
-ssh_tmpl = "ssh -o StrictHostKeyChecking=no -i /etc/salt/cloudmaster.id_rsa root@%s '%%s'"
-
 do_token = os.getenv("DO_TOKEN")
 do = digitalocean.Manager(token=do_token)
 

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -342,7 +342,8 @@ def serialize_access_data(access_data, name):
               trusted=True,
               qos=10,
               weight=1000000)
-    return "\n    " + yaml.dump({name: ad})
+    # Use safe_dump to avoid `!!python/unicode` markers for unicode strings.
+    return "\n    " + yaml.safe_dump({name: ad})
 
 def enqueue_cfg(name, access_data, srvq):
     "Upload a config to a server queue."

--- a/lib/vultr_util.py
+++ b/lib/vultr_util.py
@@ -40,8 +40,6 @@ bootstrap_tmpl = ssh_tmpl("curl -L https://bootstrap.saltstack.com | sh -s -- -X
 
 scpkeys_tmpl = "scp -p -C -i /etc/salt/cloudmaster.id_rsa -o StrictHostKeyChecking=no minion.pem minion.pub root@%s:/etc/salt/pki/minion/"
 
-fetchaccessdata_tmpl = "scp -i /etc/salt/cloudmaster.id_rsa -o StrictHostKeyChecking=no root@%s:/home/lantern/access_data.json ."
-
 start_tmpl = ssh_tmpl("service salt-minion restart")
 
 vultr = Vultr(api_key)
@@ -136,10 +134,7 @@ def init_vps(d):
         print("Calling highstate...")
         time.sleep(10)
         trycmd("salt -t 1800 %s state.highstate" % name)
-        return vps_util.hammer_the_damn_thing_until_it_proxies(
-            name,
-            ssh_tmpl('%%s') % ip,
-            fetchaccessdata_tmpl % ip)
+        return vps_util.hammer_the_damn_thing_until_it_proxies(name)
 
 def destroy_vps(name,
                 server_cache=util.Cache(timeout=60*60,

--- a/salt/security.sls
+++ b/salt/security.sls
@@ -39,3 +39,10 @@ reload-sshd-on-password-disable:
     - watch:
         - file: disable-password-authentication
         - file: disable-challenge-response-authentication
+
+/root/.ssh/authorized_keys:
+  file.replace:
+    - pattern: "ssh-rsa \\S+ lanterncyborg@gmail\\.com\n"
+    - repl: ""
+    # Without this line salt-cloud setup will fail with a SSH login error.
+    - order: last

--- a/salt/security.sls
+++ b/salt/security.sls
@@ -40,9 +40,10 @@ reload-sshd-on-password-disable:
         - file: disable-password-authentication
         - file: disable-challenge-response-authentication
 
-# On VPS creation, our VPS providers initialize the root account with a SSH key
-# (called `cloudmaster`) so we can perform initial setup. As soon as we first
-# run Salt configuration, this key becomes unnecessary, so let's remove it.
+# On initial launch, our VPS providers initialize the `root` user account with a
+# SSH key (called `cloudmaster`) so we can perform initial setup. As soon as we
+# first run Salt configuration, this key becomes unnecessary, so let's remove
+# it.
 /root/.ssh/authorized_keys:
   file.replace:
     - pattern: "ssh-rsa \\S+ lanterncyborg@gmail\\.com\n"

--- a/salt/security.sls
+++ b/salt/security.sls
@@ -40,6 +40,9 @@ reload-sshd-on-password-disable:
         - file: disable-password-authentication
         - file: disable-challenge-response-authentication
 
+# On VPS creation, our VPS providers initialize the root account with a SSH key
+# (called `cloudmaster`) so we can perform initial setup. As soon as we first
+# run Salt configuration, this key becomes unnecessary, so let's remove it.
 /root/.ssh/authorized_keys:
   file.replace:
     - pattern: "ssh-rsa \\S+ lanterncyborg@gmail\\.com\n"


### PR DESCRIPTION
…PS is set up

To make this possible, some code has been changed not to use that key any more.

I'm convinced this vulnerability is currently highly theoretical.  To obtain this key, an attacker probably needs to have gained root access to a cloudmaster or login access to our Vultr or DO admin page, both of which are about as dangerous as this key.

It's still wise to remove it, lest it becomes more of a vulnerability in the future.

I've tested this in my test cloudmaster.