### PR TITLE
Issue140

### DIFF
--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -317,10 +317,10 @@ def retire_proxy(name=None, ip=None, srv=None, reason='failed checkfallbacks', p
         return
     p = pipeline or redis_shell.pipeline()
     if offload:
-        qname = 'offloadq'
+        qname = '%s:offloadq' % region_by_name(name)
     else:
-        qname = 'retireq'
-    p.rpush('%s:%s' % (cm_by_name(name), qname), '%s|%s' % (name, ip))
+        qname = '%s:retireq' % cm_by_name(name)
+    p.rpush(qname, '%s|%s' % (name, ip))
     log2redis({'op': 'retire',
                'name': name,
                'ip': ip,

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -163,7 +163,7 @@ def actually_offload_proxy(name=None, ip=None, srv=None, pipeline=None):
     clients = set(pip
                   for pip, psrv in redis_shell.hgetall(client_table_key).iteritems()
                   if psrv == packed_srv)
-    dest = vps_util.pull_from_srvq(region)
+    dest = pull_from_srvq(region)
     # It's still possible that we'll crash or get rebooted here, so the
     # destination server will be left empty. The next closed proxy compaction
     # job will find this proxy and assign some users to it or mark it for

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -151,6 +151,27 @@ def actually_close_proxy(name=None, ip=None, srv=None, pipeline=None):
     if txn is not pipeline:
         txn.execute()
 
+def actually_offload_proxy(name=None, ip=None, srv=None, pipeline=None):
+    name, ip, srv = nameipsrv(name, ip, srv)
+    region = region_by_name(name)
+    client_table_key = region + ':clientip->srv'
+    packed_srv = redis_util.pack_srv(srv)
+    #XXX: a proxy -> {clients} index is sorely needed!
+    # Getting the set of clients assigned to this proxy takes a long time
+    # currently.  Let's get it done before pulling the replacement proxy,
+    # so we're less likely to be left with an empty proxy if interrupted.
+    clients = set(pip
+                  for pip, psrv in redis_shell.hgetall(client_table_key).iteritems()
+                  if psrv == packed_srv)
+    dest = vps_util.pull_from_srvq(region)
+    # It's still possible that we'll crash or get rebooted here, so the
+    # destination server will be left empty. The next closed proxy compaction
+    # job will find this proxy and assign some users to it or mark it for
+    # retirement.
+    dest_psrv = redis_util.pack_srv(dest.srv)
+    redis_shell.hmset(client_table_key, {pip: dest_psrv for pip in clients})
+    print "Offloaded clients from %s (%s) to %s (%s)" % (name, ip, dest.name, dest.ip)
+
 def actually_retire_proxy(name, ip, pipeline=None):
     """
     While retire_proxy just enqueues the proxy for retirement, this actually
@@ -390,7 +411,6 @@ def fix_queues():
             fix_queue(qname)
         else:
             print "no queue for %s." % domain
-
 
 # Ad hoc application of the building blocks above. Leaving them around, should
 # they serve as inspiration for future fixing jobs.

--- a/salt/cloudmaster/init.sls
+++ b/salt/cloudmaster/init.sls
@@ -43,11 +43,9 @@ refill_srvq:
 
 {# Only launch regional servers from select datacenters. #}
 
-{% if (pillar['in_production']
-       or pillar['in_staging'])
-      and (svc != 'refill_region_srvq'
-           or pillar['cloudmaster_name'] in ['cm-donyc3', 'cm-vltok1', 'cm-doams3',
-                                             'cm-donyc3staging', 'cm-dosgp1staging', 'cm-doams3staging']) %}
+{% if svc != 'refill_region_srvq'
+       or pillar['cloudmaster_name'] in ['cm-donyc3', 'cm-vltok1', 'cm-doams3',
+                                         'cm-donyc3staging', 'cm-dosgp1staging', 'cm-doams3staging'] %}
 
 /etc/init/{{ svc }}.conf:
     file.managed:

--- a/salt/cloudmaster/init.sls
+++ b/salt/cloudmaster/init.sls
@@ -26,7 +26,7 @@ refill_srvq:
     - require:
        - service: refill_srvq
 
-{% for executable in ['refill_srvq', 'retire', 'destroy'] %}
+{% for executable in ['refill_srvq', 'offload', 'retire', 'destroy'] %}
 /usr/bin/{{ executable }}.py:
     file.managed:
         - source: salt://cloudmaster/{{ executable }}.py
@@ -37,6 +37,7 @@ refill_srvq:
 
 {% for svc, executable in [('refill_cm_srvq', 'refill_srvq'),
                            ('refill_region_srvq', 'refill_srvq'),
+                           ('offload', 'offload'),
                            ('retire', 'retire'),
                            ('destroy', 'destroy')] %}
 

--- a/salt/cloudmaster/offload.conf
+++ b/salt/cloudmaster/offload.conf
@@ -1,0 +1,39 @@
+# offload - upstart job file
+
+description "offload"
+author "<aranhoide@getlantern.org>"
+
+# Stanzas
+#
+# Stanzas control when and how a process is started and stopped
+# See a list of stanzas here: http://upstart.ubuntu.com/wiki/Stanzas#respawn
+
+# When to start the service
+start on runlevel [2345]
+
+# When to stop the service
+stop on runlevel [016]
+
+# Automatically restart process if crashed
+respawn
+
+# Run as root
+setuid root
+
+# Run in lantern's home directory
+chdir /home/lantern
+
+# Set environment variables for configuration and authentication
+env CM="{{ pillar['cloudmaster_name'] }}"
+export CM
+env DO_TOKEN="{{ pillar['do_token'] }}"
+export DO_TOKEN
+env VULTR_APIKEY="{{ pillar['vultr_apikey'] }}"
+export VULTR_APIKEY
+env REDIS_URL="{{ pillar['cfgsrv_redis_url'] }}"
+export REDIS_URL
+env PYTHONPATH="/usr/local/lib/pylib"
+export PYTHONPATH
+
+# Start the process, piping output prepended with a prefix to syslog
+exec /usr/bin/offload.py 2>&1 | logger -t offload

--- a/salt/cloudmaster/offload.py
+++ b/salt/cloudmaster/offload.py
@@ -21,8 +21,9 @@ def run():
         task, remover = q.next_job()
         if task:
             name, ip = task.split('|')
+            print "Offloading users from %s (%s)" % (name, ip)
             txn = redis_shell.pipeline()
-            vps_util.actually_offload_proxy(name, ip, txn)
+            vps_util.actually_offload_proxy(name, ip, pipeline=txn)
             remover(txn)
             cm = vps_util.cm_by_name(name)
             txn.lpush(cm + ':retireq', task)

--- a/salt/cloudmaster/offload.py
+++ b/salt/cloudmaster/offload.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+
+import os
+import time
+
+from redis_util import redis_shell
+import redisq
+import vps_util
+
+
+TIMEOUT = 5 * 60
+
+
+def run():
+    region = vps_util.my_region()
+    print "Starting offload server for region %s." % region
+    qname = region + ":offloadq"
+    q = redisq.Queue(qname, redis_shell, TIMEOUT)
+    while True:
+        task, remover = q.next_job()
+        if task:
+            name, ip = task.split('|')
+            txn = redis_shell.pipeline()
+            vps_util.actually_offload_proxy(name, ip, txn)
+            remover(txn)
+            cm = vps_util.cm_by_name(name)
+            txn.lpush(cm + ':retireq', task)
+            txn.execute()
+        else:
+            time.sleep(10)
+
+
+if __name__ == '__main__':
+    run()

--- a/salt/http_proxy/check_vultr_transfer.py
+++ b/salt/http_proxy/check_vultr_transfer.py
@@ -77,9 +77,9 @@ def run():
               usage * 100))
     if usage > retire_threshold:
         print "Retiring because I", msg
-        util.offload_if_closed()
+        closed = util.am_I_closed()
         util.close_server(msg)
-        util.retire_server(msg)
+        util.retire_server(msg, offload=closed)
     elif t > significant_time and usage > significant_usage and usage > t:
         msg += " in %.2f%% of the current month" % (t * 100)
         print "closing because I", msg

--- a/salt/http_proxy/check_vultr_transfer.py
+++ b/salt/http_proxy/check_vultr_transfer.py
@@ -77,6 +77,7 @@ def run():
               usage * 100))
     if usage > retire_threshold:
         print "Retiring because I", msg
+        util.offload_if_closed()
         util.close_server(msg)
         util.retire_server(msg)
     elif t > significant_time and usage > significant_usage and usage > t:

--- a/salt/http_proxy/init.sls
+++ b/salt/http_proxy/init.sls
@@ -27,6 +27,7 @@ fp-dirs:
     ('/etc/init/', 'http-proxy.conf', 'http-proxy.conf', 'root', 644),
     ('/home/lantern/', 'util.py', 'util.py', 'lantern', 400),
     ('/home/lantern/', 'check_load.py', 'check_load.py', 'lantern', 700),
+    ('/home/lantern/', 'check_vultr_transfer.py', 'check_vultr_transfer.py', 'lantern', 700),
     ('/home/lantern/', 'auth_token.txt', 'auth_token.txt', 'lantern', 400),
     ('/home/lantern/', 'config.ini', 'config.ini', 'lantern', 400),
     ('/home/lantern/', 'fallback.json', 'fallback.json', 'lantern', 400)] %}
@@ -132,14 +133,6 @@ uptime:
     - user: lantern
 
 {% if pillar['datacenter'].startswith('vl') %}
-
-/home/lantern/check_vultr_transfer.py:
-    file.managed:
-        - source: salt://http_proxy/check_vultr_transfer.py
-        - template: jinja
-        - user: lantern
-        - group: lantern
-        - mode: 700
 
 {% set offset=[0, 1, 2]|random %}
 "/home/lantern/check_vultr_transfer.py 2>&1 | logger -t check_vultr_transfer":

--- a/salt/http_proxy/util.py
+++ b/salt/http_proxy/util.py
@@ -2,7 +2,7 @@ import datetime
 import os
 
 from alert import alert, send_to_slack
-from redis_util import redis_shell
+from redis_util import redis_shell, pack_srv
 import vps_util
 
 auth_token = "{{ pillar['cfgsrv_token'] }}"
@@ -15,9 +15,41 @@ close_flag_filename = "server_closed"
 retire_flag_filename = "server_retired"
 
 
-
 def flag_as_done(flag_filename):
     file(flag_filename, 'w').write(str(datetime.datetime.utcnow()))
+
+def offload_if_closed():
+    # XXX: assumes that users will fit in the replacement server.
+    # As of this writing, while there are some 1GB Vultr proxies, their load
+    # should fit in a 768MB one, because that's what closed proxy compaction
+    # jobs normalize for.
+    # There are also some dedicated proxies serving way too many users for a
+    # 768MB one, but I'll offload and retire these manually.
+    srv = redis_shell.hget('name->srv', instance_id)
+    if srv is None:
+        print "I'm retired or a baked in proxy; I can't offload myself."
+        return
+    if redis_shell.zscore(region + ':slices', srv) is not None:
+        print "I'm open, so no point in offloading myself"
+        return
+    print "Offloading clients before retiring myself..."
+    packed_srv = pack_srv(srv)
+    client_table_key = region + ':clientip->srv'
+    #XXX: a reverse index is sorely needed!
+    # Getting the set of clients assigned to this proxy takes a long time
+    # currently.  Let's get it done before pulling the replacement server,
+    # so we're less likely to be left with an empty server.
+    clients = set(pip
+                  for pip, psrv in redis_shell.hgetall(client_table_key).iteritems()
+                  if psrv == packed_srv)
+    dest = vps_util.pull_from_srvq(region)
+    # It's still possible that we'll crash or get rebooted here, so the
+    # destination server will be left empty. The next closed proxy compaction
+    # job will find this proxy and assign some users to it or mark it for
+    # retirement.
+    dest_psrv = pack_srv(dest.srv)
+    redis_shell.hmset(client_table_key, {pip: dest_psrv for pip in clients})
+    print "Offloaded clients to %s (%s)" % (dest.name, dest.ip)
 
 def close_server(msg):
     if os.path.exists(close_flag_filename):


### PR DESCRIPTION
Implements #140.

Tested following this script:

```org
**** Servers start up correctly in test cloudmaster
Just update, highstate, and service status for offload.  Don't care much about the rest at this point.
**** Set up
***** One proxy in the srv tables which I can make open or closed, to test the two paths
use pull_from_srvq without replacement
name='fp-https-doams3ara-20160425-011', ip='178.62.221.149', srv=1
***** One proxy in ir:srvq, to pull in order to take the users of the previous one
***** A backup of such ir:srvq, so we can reset it for further testing
***** An ir:slices table with the first proxy in it, to test that open proxies won't be offloaded
***** An ir:clientip->srv table with some users assigned to the first proxy (and others assigned to bogus server IDs)
***** Kill the retire server, so we can see and reset the entries in the retire queue as we test various scenarios
but note that highstate will restart it!
***** Edit check_vultr_transfer so it will retire the proxy unconditionally
the logic to determine whether a proxy should be retired at all is working well in production and isn't affected by this change
**** Open servers don't offload themselves
***** add an entry to ir:slices with the proxy's srvid as the key
***** manually run the check_vultr_transfer.py script, watching syslog
***** Verify that
****** the relevant printout is displayed
****** the server is enqueued for retirement
****** the ir:clientip->srv table doesn't change at all
****** the replacement proxy is still in ir:srvq
**** Closed servers offload themselves
***** delete the entry for the proxy in retireq
***** remove the entry for the proxy in ir:slices
***** manually run check_vultr_transfer.py again
***** verify that:
****** the relevant printout is displayed
****** the server is enqueued for retirement
****** the server in ir:srvq has been pulled from the queue
****** the users from the original server are assigned to the new one
****** no other users have been touched
```