### PR TITLE
Partial configuration for Digital Ocean-based config servers

### DIFF
--- a/lib/do_util.py
+++ b/lib/do_util.py
@@ -15,9 +15,10 @@ do_token = os.getenv("DO_TOKEN")
 do = digitalocean.Manager(token=do_token)
 
 
-def create_vps(name, req):
+def create_vps(name, req={}, plan=None):
     vps_util.save_pillar(name, req)
-    plan = vps_util.dc_by_cm(vps_util.my_cm()) + "_512MB"
+    if plan is None:
+        plan = vps_util.dc_by_cm(vps_util.my_cm()) + "_512MB"
     out = subprocess.check_output(["salt-cloud", "-p", plan, name])
     # Uberhack: XXX update with salt version...
     d = yaml.load(out[out.rfind(name + ":"):].replace("----------", "").replace("|_", "-")).values()[0]

--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -230,6 +230,22 @@ def todaystr():
     now = datetime.utcnow()
     return "%d%02d%02d" % (now.year, now.month, now.day)
 
+def new_vps_serial(prefix, cm=None, datestr=None):
+    if cm is None:
+        cm = my_cm()
+    if datestr is None:
+        datestr = todaystr()
+    key = 'serial:%s:%s:%s' % (cm, prefix, datestr)
+    p = redis_shell.pipeline()
+    p.incr(key)
+    p.expire(key, 25 * 60 * 60)
+    return p.execute()[0]
+
+def new_vps_name(prefix):
+    date = todaystr()
+    cm = my_cm()
+    return "-".join([prefix, cm, date, str(new_vps_serial(prefix, cm, date)).zfill(3)])
+
 def my_cm():
     """
     The name of the cloudmaster managing me, excluding the 'cm-' prefix.

--- a/salt/cloudmaster/init.sls
+++ b/salt/cloudmaster/init.sls
@@ -8,6 +8,7 @@ include:
 update-config-server-uberjar:
   cmd.run:
     - name: "cp -f /home/lantern/config-server.jar /srv/salt/config_server/config-server.jar"
+    - unless: "[ ! -e /home/lantern/config-server.jar ]"
 
 /etc/ufw/applications.d/salt:
     file.managed:

--- a/salt/cloudmaster/init.sls
+++ b/salt/cloudmaster/init.sls
@@ -3,6 +3,12 @@ include:
     - vultr
     - redis
 
+# Quick hack to get this into cloudmasters without adding it to lantern_aws.
+# config-server is in a private repo.
+update-config-server-uberjar:
+  cmd.run:
+    - name: "cp -f /home/lantern/config-server.jar /srv/salt/config_server/config-server.jar"
+
 /etc/ufw/applications.d/salt:
     file.managed:
         - source: salt://cloudmaster/ufw-rules-salt
@@ -146,4 +152,10 @@ redis-server:
 /usr/bin/kill_running_highstates.py:
   file.managed:
     - source: salt://cloudmaster/kill_running_highstates.py
+    - mode: 755
+
+# Utility to launch config servers (XXX: generalize).
+/usr/bin/launch_config_server.py:
+  file.managed:
+    - source: salt://cloudmaster/launch_config_server.py
     - mode: 755

--- a/salt/cloudmaster/launch_config_server.py
+++ b/salt/cloudmaster/launch_config_server.py
@@ -8,7 +8,7 @@ import vps_util
 
 def launch_config_server():
     # XXX: this doesn't perform a complete setup yet.
-    name = vps_util.new_vps_name('cs')
+    name = vps_util.new_vps_name('cs', plan=vps_util.my_cm() + '_8GB')
     d = do_util.create_vps(name)
     if not vps_util.highstate_pid(name):
         print("Highstate not running yet; waiting for a bit just in case...")

--- a/salt/cloudmaster/launch_config_server.py
+++ b/salt/cloudmaster/launch_config_server.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import time
+
+import do_util
+import vps_util
+
+
+def launch_config_server():
+    # XXX: this doesn't perform a complete setup yet.
+    name = vps_util.new_vps_name('cs')
+    d = do_util.create_vps(name)
+    if not vps_util.highstate_pid(name):
+        print("Highstate not running yet; waiting for a bit just in case...")
+        time.sleep(10)
+    while vps_util.highstate_pid(name):
+        print("Highstate still running...")
+        time.sleep(10)
+
+if __name__ == '__main__':
+    launch_config_server()

--- a/salt/cloudmaster/refill_srvq.py
+++ b/salt/cloudmaster/refill_srvq.py
@@ -97,7 +97,7 @@ def run():
                 if reqid in pending:
                     print "Killing task %s because of queue timeout" % reqid
                     kill_task(reqid)
-                name = get_lcs_name(req)
+                name = new_proxy_name(req)
                 proc = multiprocessing.Process(target=launch_one_server,
                                                args=(procq,
                                                      reqid,
@@ -120,18 +120,9 @@ def run():
                     kill_task(reqid)
         time.sleep(10)
 
-def get_lcs_name(req):
-    date = vps_util.todaystr()
-    if redis_shell.get(CM + ':lcsserial:date') == date:
-        serial = redis_shell.incr(CM + ':lcsserial')
-    else:
-        pipe = redis_shell.pipeline()
-        pipe.set(CM + ':lcsserial:date', date)
-        pipe.set(CM + ':lcsserial', 1)
-        pipe.execute()
-        serial = 1
-    type_prefix = 'obfs4' if 'obfs4_port' in req else 'https'
-    return 'fp-%s-%s-%s-%03d' % (type_prefix, CM, date, serial)
+def new_proxy_name(req):
+    type_str = 'obfs4' if 'obfs4_port' in req else 'https'
+    return vps_util.new_vps_name('fp-' + type_str)
 
 def launch_one_server(q, reqid, name, req_string):
     req = json.loads(req_string)

--- a/salt/config_server/config-server.conf
+++ b/salt/config_server/config-server.conf
@@ -1,0 +1,13 @@
+description "config-server http daemon"
+author "Alan Hoyte (aranhoide@gmail.com)"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+chdir /home/lantern
+
+# the `su` is only to get /etc/environment variables; nginx will launch worker
+# processes as user `nginx`.
+exec su lantern -c "java -jar /home/lantern/config-server.jar 2>&1 | logger -t config-server" 2>&1 | logger -t config-server

--- a/salt/config_server/config-server.conf
+++ b/salt/config_server/config-server.conf
@@ -8,6 +8,4 @@ respawn
 
 chdir /home/lantern
 
-# the `su` is only to get /etc/environment variables; nginx will launch worker
-# processes as user `nginx`.
 exec su lantern -c "java -jar /home/lantern/config-server.jar 2>&1 | logger -t config-server" 2>&1 | logger -t config-server

--- a/salt/config_server/init.sls
+++ b/salt/config_server/init.sls
@@ -1,0 +1,30 @@
+include:
+  - redis
+
+cfgsrv-env:
+  file.append:
+    - name: /etc/environment
+    - text: |
+        AUTH_TOKEN={{ pillar['cfgsrv_token'] }}
+        REDISCLOUD_URL={{ pillar['cfgsrv_redis_url'] }}
+        PRODUCTION=true
+        PORT=62000
+
+/home/lantern/config-server.jar:
+  file.managed:
+    - source: salt://config_server/config-server.jar
+    - mode: 755
+    - owner: lantern
+
+/etc/init/config-server.conf:
+  file.managed:
+    - source: salt://config_server/config-server.conf
+    - mode: 644
+    - template: jinja
+
+config-server:
+  service.running:
+    - enable: yes
+    - watch:
+        - file: /home/lantern/config-server.jar
+        - file: /etc/init/config-server.conf

--- a/salt/salt_cloud/cloud.profiles
+++ b/salt/salt_cloud/cloud.profiles
@@ -5,7 +5,7 @@
                         ('nyc3', 'New York 3'),
                         ('sfo1', 'San Francisco 1'),
                         ('sgp1', 'Singapore 1')] %}
-{% for size in ['512MB', '1GB', '2GB'] %}
+{% for size in ['512MB', '1GB', '2GB', '4GB', '8GB', '16GB', '32GB', '48GB', '64GB'] %}
 do{{ dc }}_{{ size }}:
     provider: do
     image: "14.04.4 x64"

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -38,4 +38,4 @@ base:
     'cs-*':
         - lantern_build_prereqs
         - proxy_ufw_rules
-        - redis
+        - config_server


### PR DESCRIPTION
As of this writing, the uberjar itself needs to be manually built and uploaded to the cloudmaster, then you need to call highstate on the cloudmaster itself before launching/updating config servers.

Launch a config server by calling `launch_config_server.py` as root.  After that, you'll need to manually add it to the Cloudflare round robin.

This is as much automation as made sense for a first shot at launching some 2-8 config servers.