### PR TITLE
fix parallel SSH

### DIFF
--- a/lib/misc_util.py
+++ b/lib/misc_util.py
@@ -59,7 +59,7 @@ def ssh(ip, cmd, timeout=30, whitelist=True):
     if whitelist:
         whitelist_ssh()
     return cmd_error_and_output(
-        ['ssh', '-o', 'StrictHostKeyChecking=no', 'lantern@' + ip, cmd],
+        ['ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'BatchMode=yes', 'lantern@' + ip, cmd],
         timeout)
 
 def whitelist_ssh(time=60):

--- a/lib/misc_util.py
+++ b/lib/misc_util.py
@@ -5,10 +5,16 @@ from functools import wraps
 import re
 import multiprocessing
 import sys
-import subprocess
 import time
 import traceback
-
+try:
+    # Backport of the Python 3 version of subprocess, used for the timeout.
+    import subprocess32 as subprocess
+except ImportError:
+    print >> sys.stderr
+    print >> sys.stderr, "*** try `pip install subprocess32` ***"
+    print >> sys.stderr
+    raise
 
 class Cache:
     def __init__(self, timeout, update_fn):
@@ -49,12 +55,12 @@ class defaultobj(defaultdict):
     def __setattr__(self, name, value):
         return self.__setitem__(name, value)
 
-def ssh(ip, cmd, timeout=60, whitelist=True):
+def ssh(ip, cmd, timeout=30, whitelist=True):
     if whitelist:
         whitelist_ssh()
     return cmd_error_and_output(
-        with_timeout(['ssh', '-o', 'StrictHostKeyChecking=no', 'lantern@' + ip, cmd],
-                     timeout))
+        ['ssh', '-o', 'StrictHostKeyChecking=no', 'lantern@' + ip, cmd],
+        timeout)
 
 def whitelist_ssh(time=60):
     try:
@@ -76,17 +82,13 @@ def whitelist_ssh(time=60):
     if ttl < time:
         redis_shell.setex(key, 'admin', time)
 
-def with_timeout(args, timeout=None):
-    if timeout is None:
-        return args
-    else:
-        return ['timeout', str(timeout)] + args
-
-def cmd_error_and_output(args):
+def cmd_error_and_output(args, timeout=120):
     try:
-        return 0, subprocess.check_output(args)
+        return 0, subprocess.check_output(args, timeout=timeout)
     except subprocess.CalledProcessError as e:
         return e.returncode, e.output
+    except subprocess.TimeoutExpired as e:
+        return 'timeout-expired', "%s -> %r" % (e.cmd, e.output)
     except Exception as e:
         return 'python-exception', traceback.format_exc()
 

--- a/salt/base_prereqs.sls
+++ b/salt/base_prereqs.sls
@@ -26,10 +26,13 @@ base-packages:
             - python-dev
         - reload_modules: yes
 
-requests:
+base-pips:
   pip.installed:
     - upgrade: yes
     - order: 1
+    - names:
+        - requests
+        - subprocess32
 
 transit-python:
   pip.installed:


### PR DESCRIPTION
For some reason, timeout didn't work in subprocess.check_output when SSHing
into a site that demands a password.

This is needed by secret_lib.interactive_offload.

Tested by using it there.  I also tested that pushing this to my test
cloudmaster worked fine and that subprocess32 could be imported there
afterwards.