### PR TITLE
Bumped up file descriptor limit on config-server

### DIFF
--- a/salt/config_server/config-server.conf
+++ b/salt/config_server/config-server.conf
@@ -7,5 +7,5 @@ stop on runlevel [!2345]
 respawn
 
 chdir /home/lantern
-
+limit nofile 128000 128000
 exec su lantern -c "java -Xms800m -Xmx1600m -jar /home/lantern/config-server.jar 2>&1 | logger -t config-server" 2>&1 | logger -t config-server


### PR DESCRIPTION
I tested this by manually applying this config to a single config-server in production. The server came up correctly and /proc/<pid>/limits showed the right file descriptor limit. Curling my config from that server succeeded as well.