### PR TITLE
make offloadq robust to no longer existing proxies

### DIFF
--- a/lib/vps_util.py
+++ b/lib/vps_util.py
@@ -151,8 +151,16 @@ def actually_close_proxy(name=None, ip=None, srv=None, pipeline=None):
     if txn is not pipeline:
         txn.execute()
 
+class ProxyGone(Exception):
+    def __init__(self, name, ip, srv):
+        self.name = name
+        self.ip = ip
+        self.srv = srv
+
 def actually_offload_proxy(name=None, ip=None, srv=None, pipeline=None):
     name, ip, srv = nameipsrv(name, ip, srv)
+    if srv is None:
+        raise ProxyGone(name, ip, srv)
     region = region_by_name(name)
     client_table_key = region + ':clientip->srv'
     packed_srv = redis_util.pack_srv(srv)


### PR DESCRIPTION
Fixes #196.

These may happen as a result of normal ops and perhaps other (already ticketed) inconsistencies.