### PR TITLE
make sshalert.py ask the ops panel instead of redis

### DIFF
--- a/bin/update.py
+++ b/bin/update.py
@@ -135,6 +135,8 @@ def upload_pillars(as_root=False):
         # Bypass stunnel in dev environments because we're not encrypting connections to Redis
         redis_via_stunnel_url = cfgsrv_redis_url
 
+    ssh_whitelist_query_token = util.read_ssh_whitelist_query_token()
+
     util.ssh_cloudmaster((
             'echo "salt_version: %s" > salt.sls '
             # Hack so every instance will read specific pillars from a file
@@ -152,6 +154,7 @@ def upload_pillars(as_root=False):
             ' && echo "redis_domain: %s" >> global.sls'
             ' && echo "slack_webhook_url: %s" >> global.sls '
             ' && echo "cloudmaster_name: %s" >> global.sls '
+            ' && echo "ssh_whitelist_query_token: %s" >> global.sls '
             ' && echo "do_token: %s" > do_credential.sls'
             ' && echo "vultr_apikey: %s" > vultr_credential.sls'
             ' && echo "linode_password: \'%s\'" > linode_credential.sls '
@@ -177,6 +180,7 @@ def upload_pillars(as_root=False):
                  redis_domain,
                  slack_webhook_url,
                  config.cloudmaster_name,
+                 ssh_whitelist_query_token,
                  do_token,
                  vultr_apikey,
                  linode_password,

--- a/bin/util.py
+++ b/bin/util.py
@@ -29,6 +29,10 @@ def in_dev():
     return not in_production() and not in_staging()
 
 @memoized
+def read_ssh_whitelist_query_token():
+    return secrets_from_yaml(['lantern_aws', 'ops_panel.yaml'],
+                             ['ssh_whitelist_query_token'])[0]
+@memoized
 def read_do_credential():
     return secrets_from_yaml(['lantern_aws', 'do_credential'],
                              ['client_id', 'api_key', 'rw_token'])

--- a/salt/sshalert/init.sls
+++ b/salt/sshalert/init.sls
@@ -1,3 +1,10 @@
+ssh-whitelist-query-token-env-var:
+  file.replace:
+    - name: /etc/environment
+    - pattern: "^SSH_WHITELIST_QUERY_TOKEN=.*$"
+    - repl: SSH_WHITELIST_QUERY_TOKEN="{{ pillar['ssh_whitelist_query_token'] }}"
+    - append_if_not_found: yes
+
 /usr/bin/sshalert.py:
   file.managed:
     - source: salt://sshalert/sshalert.py


### PR DESCRIPTION
Not the most important issue but I got enough of a head start on this when redis was down that I thought I'd just go ahead and end this big PITA that is hussh/redis whitelisting, especially in test cloudmasters.

This change makes all VPSs check for whitelisted IPs by calling an endpoint in our ops panel.  If our ops panel is down, the user will be assumed to be whitelisted.

To whitelist yourself in the ops panel, just log into `ops.panel.io` with your github account.  If you are a member of the getlantern organization, your IP will get whitelisted.  Note that you need to give your app permission to see your membership (the membership of some Lantern devs is not public).

If you leave the `ops.panel.io` tab open, it will keep whitelisting your IP even if it changes.  Useful if you're tethering in a train or something, I guess. :)